### PR TITLE
fix problem with python version

### DIFF
--- a/{{cookiecutter.project_name}}/services/apistar/Dockerfile
+++ b/{{cookiecutter.project_name}}/services/apistar/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3.6
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
numpy failed to compile using the "latest" version from python:3
using python:3.6 fixes the issue

issue remains if using python:3.7

I did this fix for myself, and thought you might be interested in merging it back on your side (or find a solution you find more suitable ;-))